### PR TITLE
Metadata improvements

### DIFF
--- a/app/Http/Controllers/DecisionController.php
+++ b/app/Http/Controllers/DecisionController.php
@@ -10,9 +10,17 @@ class DecisionController extends Controller
     public function index(Request $request)
     {
         $page = $this->getCurrentPageNumber($request);
+
         $items = $this->withCache("decisions.index.page$page", function () {
             return Decision::paginatedListing();
         });
+
+        $this->setSeo([
+            'title'     => __('content.decision.title'),
+            'routeName' => 'decisions.index',
+            'routeArg'  => 'page',
+            'page'      => $page,
+        ]);
 
         return view('decisions.index', [
             'items' => $items,
@@ -26,8 +34,11 @@ class DecisionController extends Controller
         });
 
         $this->setSeo([
-            'title' => $item->title,
+            'title'       => $item->title,
             'description' => $item->content,
+            'routeName'   => 'decisions.show',
+            'routeArg'    => 'slug',
+            'slug'        => $slug,
         ]);
 
         return view('decisions.show', [

--- a/app/Http/Controllers/NewsController.php
+++ b/app/Http/Controllers/NewsController.php
@@ -10,9 +10,17 @@ class NewsController extends Controller
     public function index(Request $request)
     {
         $page = $this->getCurrentPageNumber($request);
+
         $items = $this->withCache("news.index.page$page", function () {
             return News::paginatedListing();
         });
+
+        $this->setSeo([
+            'title'     => __('content.news.title'),
+            'routeName' => 'news.index',
+            'routeArg'  => 'page',
+            'page'      => $page,
+        ]);
 
         return view('news.index', [
             'items' => $items,
@@ -26,8 +34,11 @@ class NewsController extends Controller
         });
 
         $this->setSeo([
-            'title' => $item->title,
+            'title'       => $item->title,
             'description' => $item->content,
+            'routeName'   => 'news.show',
+            'routeArg'    => 'slug',
+            'slug'        => $slug,
         ]);
 
         return view('news.show', [

--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -18,8 +18,11 @@ class PageController extends Controller
         });
 
         $this->setSeo([
-            'title' => $item->title,
+            'title'       => $item->title,
             'description' => $item->content,
+            'routeName'   => 'pages.show',
+            'routeArg'    => 'slug',
+            'slug'        => $slug,
         ]);
 
         return view('pages.show', [

--- a/app/Http/Controllers/VideoController.php
+++ b/app/Http/Controllers/VideoController.php
@@ -10,9 +10,17 @@ class VideoController extends Controller
     public function index(Request $request)
     {
         $page = $this->getCurrentPageNumber($request);
+
         $items = $this->withCache("video.index.page{$page}", function () {
             return Video::paginatedListing();
         });
+
+        $this->setSeo([
+            'title'     => __('content.video.title'),
+            'routeName' => 'videos.index',
+            'routeArg'  => 'page',
+            'page'      => $page,
+        ]);
 
         return view('video.index', [
             'items' => $items,
@@ -26,8 +34,11 @@ class VideoController extends Controller
         });
 
         $this->setSeo([
-            'title' => $item->title,
+            'title'       => $item->title,
             'description' => $item->content,
+            'routeName'   => 'videos.show',
+            'routeArg'    => 'slug',
+            'slug'        => $slug,
         ]);
 
         return view('video.show', [

--- a/config/seotools.php
+++ b/config/seotools.php
@@ -16,7 +16,7 @@ return [
             'title'        => $title, // set false to total remove
             'titleBefore'  => false, // Put defaults.title before page title, like 'It's Over 9000! - Dashboard'
             'description'  => $description, // set false to total remove
-            'separator'    => ' - ',
+            'separator'    => ' | ',
             'keywords'     => [],
             'canonical'    => null, // Set null for using Url::current(), set false to total remove
             'robots'       => false, // Set to 'all', 'none' or any combination of index/noindex and follow/nofollow

--- a/resources/lang/ro/pagination.php
+++ b/resources/lang/ro/pagination.php
@@ -15,5 +15,6 @@ return [
 
     'previous' => '&larr; Înapoi',
     'next' => 'Înainte &rarr;',
+    'page' => 'Pagina :page',
 
 ];


### PR DESCRIPTION
This PR adds some metadata improvements, addressing the following issues:

1. Fixes duplicate meta tile for resource index pages
2. Ensures we're generating correct canonical urls, ignoring any externally applied query params.